### PR TITLE
Introduce support for PHP 8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: php
 php:
-  - '7.1'
-  - '7.2'
   - '7.3'
   - '7.4'
+  - '8.0'
 
 before_script:
   - composer install

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: php
 php:
   - '7.3'
   - '7.4'
-  - '8.0'
+  - 'nightly'
 
 before_script:
   - composer install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [1.2.0] - 2020-11-29
+### Updated
+- Update PHPUnit from `^7.5` to `^9.4` in order to support PHPUnit
+- Update PHP version requirement to `^7.3 || ^8.0`
+- Run Travis on PHP versions 7.3, 7.4 and 8.0
+
 ## [1.1.0] - 2020-01-10
 ### Added
 - `\CodeOwners\ParserInterface` to enable injection of the parser

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^7.5",
+        "phpunit/phpunit": "^9.4",
         "vimeo/psalm": "^3.0",
         "squizlabs/php_codesniffer": "^3.5"
     }

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A parser and matcher for the codeowners file as used by Github, Gitlab and Bitbucket.",
     "license": "Apache-2.0",
     "require": {
-        "php": "^7.1"
+        "php": "^7.3 || ^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -13,7 +13,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "^9.4",
-        "vimeo/psalm": "^3.0",
+        "vimeo/psalm": "^4.2",
         "squizlabs/php_codesniffer": "^3.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,21 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-        xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-        colors="true"
-        failOnRisky="true"
-        failOnWarning="true"
-        verbose="true"
->
-    <testsuites>
-        <testsuite name="CodeOwners Test Suite">
-            <directory>./tests</directory>
-        </testsuite>
-    </testsuites>
-
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src</directory>
-        </whitelist>
-    </filter>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" verbose="true">
+  <coverage>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </coverage>
+  <testsuites>
+    <testsuite name="CodeOwners Test Suite">
+      <directory>./tests</directory>
+    </testsuite>
+  </testsuites>
 </phpunit>

--- a/psalm.xml
+++ b/psalm.xml
@@ -32,7 +32,6 @@
         <MissingReturnType errorLevel="info" />
         <MissingPropertyType errorLevel="info" />
         <InvalidDocblock errorLevel="info" />
-        <MisplacedRequiredParam errorLevel="info" />
 
         <PropertyNotSetInConstructor errorLevel="info" />
         <MissingConstructor errorLevel="info" />

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -20,22 +20,22 @@ class ParserTest extends TestCase
 
     public function testParsingNonExistingFileThrowsException()
     {
-        self::expectException(UnableToParseException::class);
-        self::expectExceptionMessageRegExp('/does not exist/si');
+        $this->expectException(UnableToParseException::class);
+        $this->expectExceptionMessageMatches('/does not exist/si');
         (new Parser())->parse(NON_EXISTING_FILE);
     }
 
     public function testParsingNonReadableFileThrowsException()
     {
-        self::expectException(UnableToParseException::class);
-        self::expectExceptionMessageRegExp('/is not readable/si');
+        $this->expectException(UnableToParseException::class);
+        $this->expectExceptionMessageMatches('/is not readable/si');
         (new Parser())->parse(NON_READABLE_FILE);
     }
 
     public function testParsingNonOpenableFileThrowsException()
     {
-        self::expectException(UnableToParseException::class);
-        self::expectExceptionMessageRegExp('/unable to create a reading resource/si');
+        $this->expectException(UnableToParseException::class);
+        $this->expectExceptionMessageMatches('/unable to create a reading resource/si');
         (new Parser())->parse(NON_OPENABLE_FILE);
     }
 
@@ -43,7 +43,7 @@ class ParserTest extends TestCase
     {
         $patterns = (new Parser())->parse(__DIR__ . '/Fixtures/CODEOWNERS.example');
 
-        self::assertEquals([
+        $this->assertEquals([
             new Pattern('*', ['@global-owner1', '@global-owner2']),
             new Pattern('*.js', ['@js-owner']),
             new Pattern('*.go', ['docs@example.com']),

--- a/tests/PatternMatcherTest.php
+++ b/tests/PatternMatcherTest.php
@@ -13,7 +13,7 @@ class PatternMatcherTest extends TestCase
 {
     public function testNoMatchesWillThrowException()
     {
-        self::expectException(NoMatchFoundException::class);
+        $this->expectException(NoMatchFoundException::class);
         (new PatternMatcher())->match('non-existing.file');
     }
 
@@ -24,7 +24,7 @@ class PatternMatcherTest extends TestCase
      */
     public function testCorrectMatchIsReturnedForFilename(Pattern $pattern, string $filename): void
     {
-        self::assertEquals(
+        $this->assertEquals(
             $pattern,
             (new PatternMatcher($pattern))->match($filename)
         );
@@ -83,7 +83,7 @@ class PatternMatcherTest extends TestCase
 
         $match = $matcher->match('src/foo/bar/MyClass.php');
 
-        self::assertEquals(['@owner-of-foo-bar'], $match->getOwners());
+        $this->assertEquals(['@owner-of-foo-bar'], $match->getOwners());
     }
 
     /**
@@ -96,9 +96,9 @@ class PatternMatcherTest extends TestCase
         try {
             (new PatternMatcher($pattern))->match($filename);
 
-            self::assertTrue(false, 'Pattern "' . $pattern->getPattern() . '" matches "' . $filename . '"');
+            $this->assertTrue(false, 'Pattern "' . $pattern->getPattern() . '" matches "' . $filename . '"');
         } catch (NoMatchFoundException $exception) {
-            self::assertTrue(true);
+            $this->assertTrue(true);
         }
     }
 


### PR DESCRIPTION
In order to properly support PHP 8 I want to run the unit tests against that specific version. The only way to do so is to update to version 9.4 of PHPUnit. This version upped the minimum required PHP version to 7.3. I want to guarantee that the code works - and keeps working - so I want to run continuous integration tests on all supported versions. As I have no control over what PHPUnit - or Vimeo or PHP CodeSniffer - do in upcoming releases I need to make a choice between supporting PHP 8 or supporting PHP 7.1 (or 7.2). I have decided to drop support for PHP 7.1 and PHP 7.2 in favor of supporting PHP 8.

- Update requirement for phpunit/phpunit to `^9.4`
- Replace usages of `TestCase::expectExceptionMessageRegExp()` with `TestCase::expectExceptionMessageMatches()` as the first has been removed from PHPUnit 9
- Change calls to PHPUnit assertion functions from static to instance calls as this appears to be the recommended approach
- Update PHP requirements to `^7.3 || ^8.0`
- Update Psalm to `^4.2`
- Update CHANGELOG