### PR TITLE
Add support for parsing strings directly

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0']
+        php-versions: ['7.3', '7.4', '8.0', '8.1']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/README.md
+++ b/README.md
@@ -14,6 +14,8 @@ composer require timoschinkel/codeowners
 
 ## Usage
 
+Parse `CODEOWNERS` file:
+
 ```php
 <?php
 
@@ -21,7 +23,25 @@ use CodeOwners\Parser;
 use CodeOwners\PatternMatcher;
 
 try {
-    $patterns = (new Parser())->parse($filename);
+    $patterns = (new Parser())->parseFile($filename);
+    $pattern = (new PatternMatcher(...$patterns))->match($filename);
+} catch (\CodeOwners\Exception\UnableToParseException $exception) {
+    // unable to read or parse file
+} catch (\CodeOwners\Exception\NoMatchFoundException $exception) {
+    // no match found
+}
+```
+
+Alternatively, parsing a string directly is also supported:
+
+```php
+<?php
+
+use CodeOwners\Parser;
+use CodeOwners\PatternMatcher;
+
+try {
+    $patterns = (new Parser())->parseString($contents);
     $pattern = (new PatternMatcher(...$patterns))->match($filename);
 } catch (\CodeOwners\Exception\UnableToParseException $exception) {
     // unable to read or parse file

--- a/src/ParserInterface.php
+++ b/src/ParserInterface.php
@@ -13,5 +13,12 @@ interface ParserInterface
      * @return Pattern[]
      * @throws UnableToParseException
      */
-    public function parse(string $file): array;
+    public function parseFile(string $file): array;
+
+    /**
+     * @param string $lines
+     * @return Pattern[]
+     * @throws UnableToParseException
+     */
+    public function parseString(string $lines): array;
 }

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -22,26 +22,41 @@ class ParserTest extends TestCase
     {
         $this->expectException(UnableToParseException::class);
         $this->expectExceptionMessageMatches('/does not exist/si');
-        (new Parser())->parse(NON_EXISTING_FILE);
+        (new Parser())->parseFile(NON_EXISTING_FILE);
     }
 
     public function testParsingNonReadableFileThrowsException()
     {
         $this->expectException(UnableToParseException::class);
         $this->expectExceptionMessageMatches('/is not readable/si');
-        (new Parser())->parse(NON_READABLE_FILE);
+        (new Parser())->parseFile(NON_READABLE_FILE);
     }
 
     public function testParsingNonOpenableFileThrowsException()
     {
         $this->expectException(UnableToParseException::class);
         $this->expectExceptionMessageMatches('/unable to create a reading resource/si');
-        (new Parser())->parse(NON_OPENABLE_FILE);
+        (new Parser())->parseFile(NON_OPENABLE_FILE);
     }
 
     public function testParsingResultsInPatterns()
     {
-        $patterns = (new Parser())->parse(__DIR__ . '/Fixtures/CODEOWNERS.example');
+        $patterns = (new Parser())->parseFile(__DIR__ . '/Fixtures/CODEOWNERS.example');
+
+        $this->assertEquals([
+            new Pattern('*', ['@global-owner1', '@global-owner2']),
+            new Pattern('*.js', ['@js-owner']),
+            new Pattern('*.go', ['docs@example.com']),
+            new Pattern('/build/logs/', ['@doctocat']),
+            new Pattern('docs/*', ['docs@example.com']),
+            new Pattern('apps/', ['@octocat']),
+            new Pattern('/docs/', ['@doctocat']),
+        ], $patterns);
+    }
+
+    public function testParsingStringResultsInPatterns()
+    {
+        $patterns = (new Parser())->parseString(file_get_contents(__DIR__ . '/Fixtures/CODEOWNERS.example'));
 
         $this->assertEquals([
             new Pattern('*', ['@global-owner1', '@global-owner2']),


### PR DESCRIPTION
This is specifically useful for situations where the codeowners file isn't located on the filesystem but comes from a REST API or a database when parsing.