### PR TITLE
Added support for consecutive asterisks at the beginning or end

### DIFF
--- a/src/PatternMatcher.php
+++ b/src/PatternMatcher.php
@@ -62,6 +62,8 @@ final class PatternMatcher implements PatternMatcherInterface
                 '*' => '[^\/]+',
                 '?' => '[^\/]',
                 '**' => '.*',
+                '/**' => '.*',
+                '**/' => '.*',
                 '/**/' => '\/([^\/]+\/)*',
             ];
 

--- a/tests/Fixtures/CODEOWNERS.example
+++ b/tests/Fixtures/CODEOWNERS.example
@@ -38,6 +38,22 @@ apps/ @octocat
 # directory in the root of your repository.
 /docs/ @doctocat
 
+# A leading "**" followed by a slash means match in all directories.
+# For example, "**/foo" matches file or directory "foo" anywhere,
+# the same as pattern "foo". "**/foo/bar" matches file or directory
+# "bar" anywhere that is directly under directory "foo".
+**/foo @doctocat
+
+# A trailing "/**" matches everything inside.
+# For example, "abc/**" matches all files inside directory "abc"
+# with infinite depth.
+abc/** @doctocat
+
+# A slash followed by two consecutive asterisks then a slash ma
+# zero or more directories. For example, "a/**/b" matches "a/b",
+# "a/x/b", "a/x/y/b" and so on.
+a/**/b @doctocat
+
 # In this example nobody owns the files
 # This line should be ignored by the parser.
 /src

--- a/tests/ParserTest.php
+++ b/tests/ParserTest.php
@@ -51,6 +51,9 @@ class ParserTest extends TestCase
             new Pattern('docs/*', ['docs@example.com']),
             new Pattern('apps/', ['@octocat']),
             new Pattern('/docs/', ['@doctocat']),
+            new Pattern('**/foo', ['@doctocat']),
+            new Pattern('abc/**', ['@doctocat']),
+            new Pattern('a/**/b', ['@doctocat']),
         ], $patterns);
     }
 
@@ -66,6 +69,9 @@ class ParserTest extends TestCase
             new Pattern('docs/*', ['docs@example.com']),
             new Pattern('apps/', ['@octocat']),
             new Pattern('/docs/', ['@doctocat']),
+            new Pattern('**/foo', ['@doctocat']),
+            new Pattern('abc/**', ['@doctocat']),
+            new Pattern('a/**/b', ['@doctocat']),
         ], $patterns);
     }
 }

--- a/tests/PatternMatcherTest.php
+++ b/tests/PatternMatcherTest.php
@@ -66,6 +66,11 @@ class PatternMatcherTest extends TestCase
             // does NOT match "foo/bar/file.ext"
 
             // **
+            [new Pattern('**/c', ['@owner']), 'a/c'],
+            [new Pattern('**/c', ['@owner']), 'b/c'],
+            [new Pattern('**/c', ['@owner']), 'a/b/c'],
+            [new Pattern('a/**', ['@owner']), 'a/b'],
+            [new Pattern('a/**', ['@owner']), 'a/b/c'],
             [new Pattern('a/**/b', ['@owner']), 'a/b'],
             [new Pattern('a/**/b', ['@owner']), 'a/x/b'],
             [new Pattern('a/**/b', ['@owner']), 'a/x/y/b'],


### PR DESCRIPTION
According to [CODEOWNERS Syntax doc](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners#codeowners-syntax), CODEOWNERS file uses a pattern that follows most of the same rules used in [gitignore](https://git-scm.com/docs/gitignore#_pattern_format) files.

This Pull Requests adds support for consecutive asterisks at the beginning or end (`**/foo`, `foo/**`). The case where asterisks are in the middle (`a/**/b`) was already supported.