### PR TITLE
[PHP 8.2] Run inspections on PHP 8.2

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1']
+        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2']
     name: PHP ${{ matrix.php-versions }}
 
     steps:


### PR DESCRIPTION
This will not require a new version as the only change is in the inspections.