### PR TITLE
Support for inline comments

### DIFF
--- a/src/Parser.php
+++ b/src/Parser.php
@@ -62,8 +62,8 @@ final class Parser implements ParserInterface
             return null;
         }
 
-        if (preg_match('/^(?P<file_pattern>[^\s]+)\s+(?P<owners>.+)$/si', $line, $matches) !== 0) {
-            $owners = preg_split('/\s+/', $matches['owners']);
+        if (preg_match('/^(?P<file_pattern>[^\s]+)\s+(?P<owners>[^#]+)/si', $line, $matches) !== 0) {
+            $owners = preg_split('/\s+/', trim($matches['owners']));
             return new Pattern($matches['file_pattern'], $owners);
         }
 

--- a/tests/Fixtures/CODEOWNERS.example
+++ b/tests/Fixtures/CODEOWNERS.example
@@ -13,7 +13,7 @@
 # precedence. When someone opens a pull request that only
 # modifies JS files, only @js-owner and not the global
 # owner(s) will be requested for a review.
-*.js    @js-owner
+*.js    @js-owner # This is an inline comment.
 
 # You can also use email addresses if you prefer. They'll be
 # used to look up users just like we do for commit author


### PR DESCRIPTION
Servus! Thanks for the library. I played a bit around with it with the current example file from the [Github CodeOwner Page](https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners) and saw results that looked weird. 

The result contained the splitted inline comment that is within the example file. I saw that you also have a C&P of this file but i think it is a bit older, so the inline comment was not in there. As Github is supporting those inline comments i hope this fix will suite you. Tried my best with changing the regex. 

The tests are all green but i have not added an additional one beside changing your fixtures so the tests should cover that the inline comment is not parsed into patterns. 