### PR TITLE
Remove support for PHP 7

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['7.3', '7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.0', '8.1', '8.2', '8.3']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Removed
+- Support for PHP 7 has been removed - [#27](https://github.com/timoschinkel/codeowners/pull/27)
+
 ## [2.1.0] - 2022-06-29
 ### Added
 - Added support for trailing `/**` and leading `**/` patterns - [#20](https://github.com/timoschinkel/codeowners/pull/20) by martinssipenko

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A parser and matcher for the codeowners file as used by Github, Gitlab and Bitbucket.",
     "license": "Apache-2.0",
     "require": {
-        "php": "^7.3 || ^8.0"
+        "php": "^8.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Although the code still runs fine on PHP 7, keeping it as a supported language makes using dependencies difficult; most (dev) dependencies have already dropped support for PHP 7. Given that PHP 7 has not been supported for a long time now I will drop official support for it.

If you're running PHP 7 you can continue to use the version up to 2.1.0 or you can try to run Composer using `--ignore-platform-reqs`, but in that last scenario I no longer guarantee that everything works.