### PR TITLE
Change wildcard behavior

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.1] - 2024-04-26
+### Changed
+- Change behavior or `*` from `[^/]+` to `[^/]*` - [#31](https://github.com/timoschinkel/codeowners/pull/31)
+
 ## [2.2.0] - 2024-04-10
 ### Added
 - Support for inline comments - [#25](https://github.com/timoschinkel/codeowners/pull/25) by DZunke

--- a/src/PatternMatcher.php
+++ b/src/PatternMatcher.php
@@ -59,7 +59,7 @@ final class PatternMatcher implements PatternMatcherInterface
 
         $regex = join(array_map(function (string $part) use ($delimiter): string {
             $replacements = [
-                '*' => '[^\/]+',
+                '*' => '[^\/]*',
                 '?' => '[^\/]',
                 '**' => '.*',
                 '/**' => '\/.*',

--- a/tests/PatternMatcherTest.php
+++ b/tests/PatternMatcherTest.php
@@ -61,6 +61,8 @@ class PatternMatcherTest extends TestCase
             [new Pattern('*.ext', ['@owner']), 'foo/file.ext'],
             // does NOT match "foo/ext
             [new Pattern('foo/*', ['@owner']), 'foo/file.ext'],
+            [new Pattern('foo/*.ext', ['@owner']), 'foo/file.ext'],
+            [new Pattern('foo/*.ext', ['@owner']), 'foo/.ext'],
             [new Pattern('foo/*', ['@owner']), 'bar/foo/file.ext'],
             [new Pattern('foo/*/*', ['@owner']), 'bar/foo/biz/file.ext'],
             // does NOT match "foo/bar/file.ext"
@@ -75,6 +77,9 @@ class PatternMatcherTest extends TestCase
             [new Pattern('a/**/b', ['@owner']), 'a/x/b'],
             [new Pattern('a/**/b', ['@owner']), 'a/x/y/b'],
             [new Pattern('a/**/b/**/c', ['@owner']), 'a/x/y/b/x/y/c'],
+
+            // Combined (edge) cases
+            [new Pattern('**/*Foo**', ['@owner']), 'example/FooSomething'],
         ];
     }
 


### PR DESCRIPTION
The behavior for a single wildcard - `*` - was implemented as `[^\/]+`, but as it turns out it should be implemented as `[^\/]*`. See https://github.com/timoschinkel/test-repository/pull/8

Fixes #30