### PR TITLE
Update deprecated string interpolation usage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.2.2] - 2024-07-10
+### Changed
+- Update deprecated string interpolation usage
+
 ## [2.2.1] - 2024-04-26
 ### Changed
 - Change behavior or `*` from `[^/]+` to `[^/]*` - [#31](https://github.com/timoschinkel/codeowners/pull/31)

--- a/src/PatternMatcher.php
+++ b/src/PatternMatcher.php
@@ -29,7 +29,7 @@ final class PatternMatcher implements PatternMatcherInterface
         );
 
         if (count($matchedPatterns) === 0) {
-            throw new NoMatchFoundException("Unable to find a pattern to match ${filename}");
+            throw new NoMatchFoundException("Unable to find a pattern to match {$filename}");
         }
 
         return end($matchedPatterns);


### PR DESCRIPTION
`${var}` string interpolation [has been deprecated in PHP 8.2](https://php.watch/versions/8.2/$%7Bvar%7D-string-interpolation-deprecated), update the usage to remove warnings

```
PHP message: PHP Deprecated:  Using ${var} in strings is deprecated, use {$var} instead in /var/www/vendor/timoschinkel/codeowners/src/PatternMatcher.php on line 32
```