### PR TITLE
Run inspections on PHP 8.4

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.0', '8.1', '8.2', '8.3']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
     name: PHP ${{ matrix.php-versions }}
 
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [2.3.1] - 2025-01-29
+### Removed
+- Support for PHP 8.0 
+
+### Added
+- Inspections - and thus support - for PHP 8.3 and 8.4
+
+### Changed
+- Upgrade dev dependencies
+  - `vimeo/psalm` to version 6
+  - `phpunit/phpunit` to version 10
+
 ## [2.3.0] - 2024-10-02
 ### Changed
 - Add optional source and line number information to patterns - [#34](https://github.com/timoschinkel/codeowners/pull/34) by kellegous

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "A parser and matcher for the codeowners file as used by Github, Gitlab and Bitbucket.",
     "license": "Apache-2.0",
     "require": {
-        "php": "^8.0"
+        "php": "^8.1"
     },
     "autoload": {
         "psr-4": {
@@ -12,8 +12,8 @@
         }
     },
     "require-dev": {
-        "phpunit/phpunit": "^9.4",
-        "vimeo/psalm": "^5.23",
+        "phpunit/phpunit": "^10.0",
+        "vimeo/psalm": "^6.0",
         "squizlabs/php_codesniffer": "^3.5"
     }
 }

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" verbose="true">
-  <coverage>
-    <include>
-      <directory suffix=".php">src</directory>
-    </include>
-  </coverage>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" colors="true" failOnRisky="true" failOnWarning="true" cacheDirectory=".phpunit.cache">
   <testsuites>
     <testsuite name="CodeOwners Test Suite">
       <directory>./tests</directory>
     </testsuite>
   </testsuites>
+  <source>
+    <include>
+      <directory suffix=".php">src</directory>
+    </include>
+  </source>
 </phpunit>

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -66,6 +66,11 @@ final class Parser implements ParserInterface
 
         if (preg_match('/^(?P<file_pattern>[^\s]+)\s+(?P<owners>[^#]+)/si', $line, $matches) !== 0) {
             $owners = preg_split('/\s+/', trim($matches['owners']));
+            if (!is_array($owners)) {
+                // This should not happen as we have full control over the regular expression. In case `preg_split()`
+                // fails an E_WARNING will be emitted by `preg_split()`, so we're not doing that twice.
+                throw new UnableToParseException('Unable to extract owners from line: ' . $line);
+            }
             return new Pattern($matches['file_pattern'], $owners, $sourceInfo);
         }
 

--- a/src/PatternMatcher.php
+++ b/src/PatternMatcher.php
@@ -57,6 +57,12 @@ final class PatternMatcher implements PatternMatcherInterface
             PREG_SPLIT_DELIM_CAPTURE
         );
 
+        if (!is_array($parts)) {
+            // This should not happen as we have full control over the regular expression. In case `preg_split()` fails
+            // an E_WARNING will be emitted by `preg_split()`, so we're not doing that twice.
+            return false;
+        }
+
         $regex = join(array_map(function (string $part) use ($delimiter): string {
             $replacements = [
                 '*' => '[^\/]*',

--- a/tests/PatternMatcherTest.php
+++ b/tests/PatternMatcherTest.php
@@ -30,7 +30,7 @@ class PatternMatcherTest extends TestCase
         );
     }
 
-    public function provideCorrectMatchIsReturnedForFilename(): array
+    public static function provideCorrectMatchIsReturnedForFilename(): array
     {
         return [
             [new Pattern('foo', ['@owner']), 'foo'],
@@ -112,7 +112,7 @@ class PatternMatcherTest extends TestCase
         }
     }
 
-    public function provideNoMatchFoundExceptionIsThrownForFilename(): array
+    public static function provideNoMatchFoundExceptionIsThrownForFilename(): array
     {
         return [
             [new Pattern('foo', ['@owner']), 'foo.ext'],


### PR DESCRIPTION
Now that PHP 8.4 is officially released we should run the inspections on that version as well.

In order to support PHP 8.4 `vimeo/psalm` has to be upgraded to version 6. PHP 8.0 is not support by Psalm 6. Given that PHP 8.0 itself is no longer supported that version is dropped from this library as a whole. Users on PHP 8.0 can still use all versions up until 2.3.0. Due to the bump to PHP 8.1 it also became possible to upgrade `phpunit/phpunit` to version 10. This requires some changes to the configuration and test cases, but those are relatively small.