### PR TITLE
Apply fixes for (new) Psalm rules

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.0.0] - 2026-05-04
+### Changed
+- Marked `\CodeOwners\Exception\NoMatchFoundException` and `\CodeOwners\Exception\UnableToParseException` as final
+
+## Backwards compatibility breaking changes
+If you are extending `\CodeOwners\Exception\NoMatchFoundException` or `\CodeOwners\Exception\UnableToParseException` in your code, you will need to update your code to not extend these classes.
+
 ## [2.3.1] - 2025-01-29
 ### Removed
 - Support for PHP 8.0 

--- a/src/Exception/NoMatchFoundException.php
+++ b/src/Exception/NoMatchFoundException.php
@@ -4,6 +4,6 @@ declare(strict_types=1);
 
 namespace CodeOwners\Exception;
 
-class NoMatchFoundException extends \RuntimeException
+final class NoMatchFoundException extends \RuntimeException
 {
 }

--- a/src/Exception/UnableToParseException.php
+++ b/src/Exception/UnableToParseException.php
@@ -6,6 +6,6 @@ namespace CodeOwners\Exception;
 
 use RuntimeException;
 
-class UnableToParseException extends RuntimeException
+final class UnableToParseException extends RuntimeException
 {
 }

--- a/src/Parser.php
+++ b/src/Parser.php
@@ -13,7 +13,7 @@ final class Parser implements ParserInterface
      * @return Pattern[]
      * @throws UnableToParseException
      */
-    public function parseFile(string $file): array
+    #[\Override] public function parseFile(string $file): array
     {
         return $this->parseIterable($this->getFileIterable($file), $file);
     }
@@ -24,7 +24,7 @@ final class Parser implements ParserInterface
      * @return Pattern[]
      * @throws UnableToParseException
      */
-    public function parseString(string $lines, ?string $filename = null): array
+    #[\Override] public function parseString(string $lines, ?string $filename = null): array
     {
         return $this->parseIterable(explode(PHP_EOL, $lines), $filename);
     }

--- a/src/PatternMatcher.php
+++ b/src/PatternMatcher.php
@@ -19,7 +19,7 @@ final class PatternMatcher implements PatternMatcherInterface
         $this->patterns = $patterns;
     }
 
-    public function match(string $filename): Pattern
+    #[\Override] public function match(string $filename): Pattern
     {
         $matchedPatterns = array_filter(
             $this->patterns,


### PR DESCRIPTION
While running inspections a newer version of Psalm seemingly changed some rules, breaking on `ClassMustBeFinal`.

- Mark `NoMatchFoundException` and `UnableToParseException` as final - this is a backwards compatible break
- Add `#[\Override]` attributes - these methods are defined in an interface, and are therefore by definition overridden, but alas.